### PR TITLE
Senden einer vopNavigationDeniedNotification Message und Nutzung von Material Design Elementen im Footer 

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { MatRadioModule } from '@angular/material/radio';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -33,6 +34,7 @@ import { UnitActivateGuard } from './unit-host/unit-route-guards';
     NoopAnimationsModule,
     FlexLayoutModule,
     MatButtonModule,
+    MatCheckboxModule,
     MatSnackBarModule,
     MatTooltipModule,
     MatSlideToggleModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,7 +3,7 @@ import { NgModule } from '@angular/core';
 import { HashLocationStrategy, LocationStrategy } from '@angular/common';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FlexLayoutModule } from '@angular/flex-layout';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import { MatButtonModule } from '@angular/material/button';
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -21,12 +21,14 @@ import { AppComponent } from './app.component';
 import { SettingsComponent } from './settings/settings.component';
 import { UnitHostComponent } from './unit-host/unit-host.component';
 import { UnitActivateGuard } from './unit-host/unit-route-guards';
+import { DenyNavigationComponent } from './components/deny-navigation/deny-navigation.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     SettingsComponent,
-    UnitHostComponent
+    UnitHostComponent,
+    DenyNavigationComponent
   ],
   imports: [
     BrowserModule,
@@ -43,7 +45,8 @@ import { UnitActivateGuard } from './unit-host/unit-route-guards';
     MatIconModule,
     FormsModule,
     MatFormFieldModule,
-    MatSelectModule
+    MatSelectModule,
+    ReactiveFormsModule
   ],
   providers: [
     UnitActivateGuard,

--- a/src/app/components/deny-navigation/deny-navigation.component.html
+++ b/src/app/components/deny-navigation/deny-navigation.component.html
@@ -1,0 +1,7 @@
+<form [formGroup]="form" (ngSubmit)="submit()" fxLayout="row" fxLayoutAlign="space-between center">
+    <mat-checkbox class="form-item" color="primary" value="presentationIncomplete"
+                  (change)="onCheckboxChange($event)">presentationIncomplete</mat-checkbox>
+    <mat-checkbox class="form-item" color="primary" value="responsesIncomplete"
+                  (change)="onCheckboxChange($event)">responsesIncomplete</mat-checkbox>
+    <button class="form-item" mat-flat-button color="primary" type="submit" [disabled]="!form.valid">Deny Nav</button>
+</form>

--- a/src/app/components/deny-navigation/deny-navigation.component.scss
+++ b/src/app/components/deny-navigation/deny-navigation.component.scss
@@ -1,0 +1,3 @@
+.form-item {
+  margin-left: 10px;
+}

--- a/src/app/components/deny-navigation/deny-navigation.component.spec.ts
+++ b/src/app/components/deny-navigation/deny-navigation.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DenyNavigationComponent } from './deny-navigation.component';
+import { AppModule } from '../../app.module';
+
+describe('DenyNavigationComponent', () => {
+  let component: DenyNavigationComponent;
+  let fixture: ComponentFixture<DenyNavigationComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AppModule],
+      declarations: [DenyNavigationComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DenyNavigationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/deny-navigation/deny-navigation.component.ts
+++ b/src/app/components/deny-navigation/deny-navigation.component.ts
@@ -1,0 +1,37 @@
+import { Component, Output, EventEmitter } from '@angular/core';
+import {
+  FormBuilder, FormControl, FormGroup, Validators, FormArray
+} from '@angular/forms';
+import { MatCheckboxChange } from '@angular/material/checkbox';
+
+@Component({
+  selector: 'app-deny-navigation',
+  templateUrl: './deny-navigation.component.html',
+  styleUrls: ['./deny-navigation.component.scss']
+})
+
+export class DenyNavigationComponent {
+  @Output() denyNavigation = new EventEmitter<string[]>();
+  form: FormGroup;
+
+  constructor(private formBuilder: FormBuilder) {
+    this.form = this.formBuilder.group({
+      reasons: this.formBuilder.array([], [Validators.required])
+    });
+  }
+
+  onCheckboxChange(event: MatCheckboxChange): void {
+    const reasons: FormArray = this.form.get('reasons') as FormArray;
+    if (event.checked) {
+      reasons.push(new FormControl(event.source.value));
+    } else {
+      reasons.removeAt(reasons.value.findIndex(
+        (item: FormControl): boolean => item.value === event.source.value
+      ));
+    }
+  }
+
+  submit(): void {
+    this.denyNavigation.emit(this.form.value.reasons);
+  }
+}

--- a/src/app/unit-host/unit-host.component.html
+++ b/src/app/unit-host/unit-host.component.html
@@ -32,6 +32,7 @@
             mat-flat-button color="primary"
             (click)="sendVopStopCommand()"
             title="vopStopCommand">Stop</button>
+    <app-deny-navigation (denyNavigation)="sendDenyNavigation($event)"></app-deny-navigation>
   </div>
 
   <div fxLayout="row" fxLayoutAlign="space-between center">

--- a/src/app/unit-host/unit-host.component.html
+++ b/src/app/unit-host/unit-host.component.html
@@ -16,15 +16,22 @@
   </div>
 
   <div fxLayout="row" fxLayoutAlign="space-between center">
-    <button *ngIf="displayGetStateButton()" (click)="sendVopGetStateRequest()" title="vopGetStateRequest">
-      Get State
-    </button>
-    <label *ngIf="displayGetStateButton()" title="stop after vopGetStateRequest?" style="color:white">
-      <input type="checkbox" [(ngModel)]="sendStopWithGetStateRequest">
-      Stop
-    </label>
-    <button *ngIf="displayContinueButton()" (click)="sendVopContinueCommand()" title="vopStopCommand">Continue</button>
-    <button *ngIf="displayStopButton()" (click)="sendVopStopCommand()" title="vopStopCommand">Stop</button>
+    <button *ngIf="displayGetStateButton()"
+            mat-flat-button color="primary"
+            (click)="sendVopGetStateRequest()"
+            title="vopGetStateRequest">Get State</button>
+    <mat-checkbox *ngIf="displayGetStateButton()"
+                  title="stop after vopGetStateRequest?"
+                  color="primary"
+                  [(ngModel)]="sendStopWithGetStateRequest">Stop</mat-checkbox>
+    <button *ngIf="displayContinueButton()"
+            mat-flat-button color="primary"
+            (click)="sendVopContinueCommand()"
+            title="vopStopCommand">Continue</button>
+    <button *ngIf="displayStopButton()"
+            mat-flat-button color="primary"
+            (click)="sendVopStopCommand()"
+            title="vopStopCommand">Stop</button>
   </div>
 
   <div fxLayout="row" fxLayoutAlign="space-between center">

--- a/src/app/unit-host/unit-host.component.scss
+++ b/src/app/unit-host/unit-host.component.scss
@@ -1,3 +1,12 @@
+:host ::ng-deep {
+  .mat-checkbox-frame {
+    border-color: white;
+  }
+  .mat-checkbox-label {
+    color: white;
+  }
+}
+
 #iFrameHost {
   position: absolute;
   width: 100%;

--- a/src/app/unit-host/unit-host.component.ts
+++ b/src/app/unit-host/unit-host.component.ts
@@ -444,6 +444,14 @@ export class UnitHostComponent implements OnInit, OnDestroy {
     }, '*');
   }
 
+  sendDenyNavigation(reasons: string[]): void {
+    this.postMessageTarget.postMessage({
+      type: 'vopNavigationDeniedNotification',
+      sessionId: this.itemplayerSessionId,
+      reason: reasons
+    }, '*');
+  }
+
   ngOnDestroy(): void {
     this.routingSubscription.unsubscribe();
     this.postMessageSubscription.unsubscribe();


### PR DESCRIPTION
- Die Button-Elemente des Footers wurden durch Material-Design Auszeichnungen ergänzt.
- Das CheckBox-Element des Footers wurde durch das entsprechende Material-Element ersetzt. Durch die dunkle Hintergrundfarbe des Footers musste die Schrift- und Border-Farbe der Checkbox überschrieben werden. Die grundsätztliche Einführung eines Themes wäre hierfür besser geeignet und sollte die aktuelle Lösung zukünftig ablösen.
- Die interaktiven Elemente zum Senden einer `vopNavigationDeniedNotification` und ihr Zusammenspiel wurden in der ' `DenyNavigationComponent` zusammengefasst. Auf diese Weise wird die `UnitHostComponent` nicht unnötig aufgebläht. Die Kommunikation zwischen beiden Komponenten erfolgt über den Output der  `DenyNavigationComponent` `denyNavigation`.
- Es wurden keine Tests implementiert, sondern lediglich der Standardtest zur Lauffähigkeit gebracht. 