### PR TITLE
Persist and return `unitStateDataType`

### DIFF
--- a/src/app/app.classes.ts
+++ b/src/app/app.classes.ts
@@ -8,6 +8,7 @@ export class UnitData {
   definition: string; // actual code of the unit
   restorePoint: KeyValuePairString;
   presentationCompleteState: string;
+  responseType: string;
 
   constructor(fileName: string, sequId: number) {
     this.filename = fileName;
@@ -17,6 +18,7 @@ export class UnitData {
     this.definition = '';
     this.restorePoint = {};
     this.presentationCompleteState = '';
+    this.responseType = '';
   }
 
   public loadDefinition(file: File): void {

--- a/src/app/unit-host/unit-host.component.ts
+++ b/src/app/unit-host/unit-host.component.ts
@@ -222,13 +222,15 @@ export class UnitHostComponent implements OnInit, OnDestroy {
           }
           UnitHostComponent.log(LogEntryKey.PAGENAVIGATIONSTART, '#first');
           this.postMessageTarget = m.source as Window;
+
           if (typeof this.postMessageTarget !== 'undefined') {
             this.postMessageTarget.postMessage({
               type: 'vopStartCommand',
               sessionId: this.itemplayerSessionId,
               unitDefinition: pendingUnitDef,
               unitState: {
-                dataParts: pendingUnitDataToRestore
+                dataParts: pendingUnitDataToRestore,
+                unitStateDataType: this.tcs.unitList[this.tcs.currentUnitSequenceId].responseType
               },
               playerConfig: this.tcs.playerConfig
             }, '*');
@@ -261,6 +263,9 @@ export class UnitHostComponent implements OnInit, OnDestroy {
                 UnitHostComponent.logResponse(dataParts, unitStateDataType);
                 UnitHostComponent.logRestorePoint(dataParts);
                 this.tcs.unitList[this.tcs.currentUnitSequenceId].restorePoint = dataParts;
+                if (unitStateDataType) {
+                  this.tcs.unitList[this.tcs.currentUnitSequenceId].responseType = unitStateDataType;
+                }
               }
             }
           }


### PR DESCRIPTION
Um zu überprüfen, ob die als dataParts persistierten Antworten in der richtigen Version vorliegen, wird der unitStateDataType benötigt. Das Testbed legt diesen Wert nun bei 'vopStateChangedNotification'  in den UnitData als responseType ab und liefert ihn  bei 'vopStartCommand' an den Player aus.